### PR TITLE
Add missing ORLY? command

### DIFF
--- a/lib/lita/handlers/imgflip.rb
+++ b/lib/lita/handlers/imgflip.rb
@@ -143,6 +143,10 @@ module Lita
         generate_meme(response, 356615)
       end
 
+      def meme_orly(response)
+        generate_meme(response, 12361203)
+      end
+
       private
 
       def khanify(phrase)


### PR DESCRIPTION
Previously, there was no `meme_orly` method in this handler, meaning that an exception would be raised every time Lita heard text containing the phrase `o rly?`. This changeset adds the missing `meme_orly` method.
