### PR TITLE
Use boundary character instead of space for "orly"

### DIFF
--- a/lib/lita/handlers/imgflip.rb
+++ b/lib/lita/handlers/imgflip.rb
@@ -10,7 +10,7 @@ module Lita
 
       route %r{(Y U NO) (.+)}i,                                    :meme_y_u_no,             help: { "Y U NO..." => "generates Y U NO meme"}
       route %r{(I DON'?T ALWAYS .*) (BUT WHEN I DO,? .*)}i,        :meme_i_dont_always,      help: { "I DON'T ALWAYS .. BUT WHEN I DO, .." => "generates The Most Interesting Man in the World meme"}
-      route %r{(.*) (O\s?RLY\??.*)}i,                              :meme_orly,               help: { "..O RLY.." => "generates O RLY meme" }
+      route %r{(.*)\b(O\s?RLY\??.*)}i,                             :meme_orly,               help: { "..O RLY.." => "generates O RLY meme" }
       route %r{(.*)(SUCCESS|NAILED IT.*)},                         :meme_success,            help: { "..SUCCESS.." => "(case sensitive) generates SUCCESS meme", "..NAILED IT.." => "generates NAILED IT meme" }
       route %r{(.*) (ALL the .*)} ,                                :meme_all_the,            help: { "ALL the.." => "(case sensitive) generates ALL the <things> meme" }
       route %r{(.*) (\w+\sTOO DAMN .*)}i,                          :meme_too_damn,           help: { "TOO DAMN.." => "generates TOO DAMN meme" }


### PR DESCRIPTION
This would match lines that start with meme as well as those that include it.
