### PR TITLE
change imgflip API protocol and http method

### DIFF
--- a/lib/lita/handlers/imgflip.rb
+++ b/lib/lita/handlers/imgflip.rb
@@ -167,14 +167,14 @@ module Lita
         text0 ||= response.matches[0][0]
         text1 ||= response.matches[0][1]
 
-        http_resp = http.get(
-          'http://api.imgflip.com/caption_image',
+        http_resp = http.post(
+          'https://api.imgflip.com/caption_image',
           username: Lita.config.handlers.imgflip.username,
           password: Lita.config.handlers.imgflip.password,
           template_id: template_id,
           text0: text0,
           text1: text1
-          )
+        )
 
         if http_resp.status == 200
           result = MultiJson.load(http_resp.body)

--- a/lita-imgflip.gemspec
+++ b/lita-imgflip.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", "~> 4.0"
+  spec.add_runtime_dependency "lita", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 11.1", ">= 11.1.2"


### PR DESCRIPTION
- imgflip API now demands HTTPS
- `caption_image` is now an HTTP POST